### PR TITLE
fix button otherprops typescript 컴파일 오류 해결

### DIFF
--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { BaseButton, InvertedButton } from './button.style';
 
-interface ButtonProp {
+interface ButtonProp extends React.ComponentPropsWithRef<'button'> {
   children?: JSX.Element | JSX.Element[] | string;
   buttonType?: string;
 }


### PR DESCRIPTION
buttonprop 인터페이스에 extends React.ComponentPropsWithRef<'button'> 추가