### PR TITLE
feat toast popup 로직 훅으로 뺌

### DIFF
--- a/src/hooks/toast.hook.ts
+++ b/src/hooks/toast.hook.ts
@@ -1,0 +1,11 @@
+import React, { useEffect, Dispatch, SetStateAction } from 'react';
+
+const ToastHook = (toastState: boolean, setToastState: Dispatch<SetStateAction<boolean>>) => {
+  useEffect(() => {
+    if (toastState) {
+      setTimeout(() => setToastState(false), 3000);
+    }
+  }, [setToastState, toastState]);
+};
+
+export default ToastHook;

--- a/src/routes/main/main.component.tsx
+++ b/src/routes/main/main.component.tsx
@@ -5,15 +5,11 @@ import MultiLink from '../../components/multi-link/multi-link.component';
 import CopyMsg from '../../components/copy-message/copy-message.component';
 import Character from '../../components/character/character.component';
 import CatImg from '../../assets/images/cat.png';
+import ToastHook from '../../hooks/toast.hook';
 
 export default function Main(): JSX.Element {
   const [toastState, setToastState] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (toastState) {
-      setTimeout(() => setToastState(false), 3000);
-    }
-  }, [toastState]);
+  ToastHook(toastState, setToastState);
 
   return (
     <div className="App">


### PR DESCRIPTION
- main 페이지에 있던 toast popup 로직을 훅으로 따로 만듦.
- main 페이지도 건들게 됐는데 어차피 지금 main은 임시고 레이아웃 새로 짜는 중이니까 문제 없을듯 
(toast는 멀티에서 필요한거)