### PR TITLE
fix: modal test 에러 수정

### DIFF
--- a/src/components/modal/modal.component.tsx
+++ b/src/components/modal/modal.component.tsx
@@ -21,6 +21,7 @@ export interface ModalProp {
   children: JSX.Element | string;
   footer?: JSX.Element | string;
   backgroundColor?: string;
+  titleColor?: string;
 }
 
 export default function Modal({
@@ -29,17 +30,14 @@ export default function Modal({
   title,
   children,
   footer,
+  titleColor = '#000',
   backgroundColor = '#fff',
   contentWidth = 500,
 }: ModalProp): JSX.Element {
   return (
     <ModalContainer className={isOpen ? 'show' : ''} onClick={onClose}>
       <ModalContent width={contentWidth} backgroundColor={backgroundColor} onClick={(e) => e.stopPropagation()}>
-        {/* <ModalHeader>
-          {title ? <ModalTitle>{title}</ModalTitle> : <div />}
-          <CloseButton onClick={onClose}>&#x2715;</CloseButton>
-         
-        </ModalHeader> */}
+        <ModalHeader>{title ? <ModalTitle titleColor={titleColor}>{title}</ModalTitle> : <div />}</ModalHeader>
         <CloseButton normalImg={CloseBtnImg} hoverImg={CloseHoverBtnImg} onClick={onClose} />
         <ModalBody>{children}</ModalBody>
 

--- a/src/components/modal/modal.style.tsx
+++ b/src/components/modal/modal.style.tsx
@@ -29,20 +29,18 @@ export const ModalContent = styled.div<{ width: number; backgroundColor: string 
 `;
 
 export const ModalHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  padding: 25px;
+  margin-top: 68px;
 `;
 
 export const ModalFooter = styled.div`
   padding: 0 32px;
-  // border-top: 1px solid #eee;
 `;
 
-export const ModalTitle = styled.div`
-  margin: 0;
-  font-weight: bold;
-  border-bottom: 1px solid #eee;
+export const ModalTitle = styled.div<{ titleColor: string }>`
+  text-align: center;
+  font-size: 36px;
+  font-family: 'neodgm';
+  color: ${({ titleColor }) => titleColor};
 `;
 
 export const ModalBody = styled.div`

--- a/src/components/multi-mode-select-modal/multi-mode-select-modal.component.tsx
+++ b/src/components/multi-mode-select-modal/multi-mode-select-modal.component.tsx
@@ -4,7 +4,6 @@ import Modal from '../modal/modal.component';
 import ModeSelectButton from '../mode-select-button/mode-select-button.component';
 import {
   MultiModeSelectModalContainer,
-  MultiModeSelectModalTitle,
   MultiModeSelectModalContent,
   MultiModeSelectModalButtonContainer,
   ModeSelectImageWrap,
@@ -24,7 +23,7 @@ export default function MultiModeSelectModal(): JSX.Element {
 
   return (
     <Modal
-      title=""
+      title="멀티모드"
       isOpen={isMultiModeSelectModalOpen}
       onClose={() => {
         dispatch(modalAction.radioMultiModeSelectModal());
@@ -33,7 +32,6 @@ export default function MultiModeSelectModal(): JSX.Element {
       backgroundColor="#FBFFD1"
     >
       <MultiModeSelectModalContainer>
-        <MultiModeSelectModalTitle>멀티모드</MultiModeSelectModalTitle>
         <MultiModeSelectModalContent>함께해야 제 맛 같이 한번 해볼까?</MultiModeSelectModalContent>
         <MultiModeSelectModalButtonContainer>
           <ModeSelectImageWrap>

--- a/src/components/multi-mode-select-modal/multi-mode-select-modal.style.tsx
+++ b/src/components/multi-mode-select-modal/multi-mode-select-modal.style.tsx
@@ -4,14 +4,6 @@ export const MultiModeSelectModalContainer = styled.div`
   padding: 24px 0;
 `;
 
-export const MultiModeSelectModalTitle = styled.div`
-  margin-top: 44px;
-  text-align: center;
-  font-size: 42px;
-  font-weight: bold;
-  font-family: 'neodgm';
-`;
-
 export const ModeSelectImageWrap = styled.button`
   border: none;
   cursor: pointer;
@@ -27,7 +19,7 @@ export const ModeSelectImage = styled.img`
 export const MultiModeSelectModalContent = styled.div`
   white-space: pre-wrap;
   text-align: center;
-  margin: 40px 0;
+  margin-bottom: 57px;
   color: grey;
   font-size: 24px;
   font-family: 'neodgm';

--- a/src/components/profile-modal/profile-modal.component.tsx
+++ b/src/components/profile-modal/profile-modal.component.tsx
@@ -31,13 +31,13 @@ export default function ProfileModal({ isOpen, onClose, nickname, characterImgSr
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      title="프로필 정보"
+      title="내 뽀모"
       contentWidth={440}
       backgroundColor="#D5D1FF"
+      titleColor="#025a00"
       footer={!user ? <SocialLoginMenu isMyPomo /> : '로그아웃 버튼'}
     >
       <ProfileModalContainer>
-        <ProfileModalTitle>내 뽀모</ProfileModalTitle>
         <ProfileModalBgImg>
           <ProfileModalCharacterImg alt="profile" src={characterImgSrc} />
         </ProfileModalBgImg>

--- a/src/components/single-mode-select-modal/single-mode-select-modal.component.tsx
+++ b/src/components/single-mode-select-modal/single-mode-select-modal.component.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import Modal from '../modal/modal.component';
 import {
   SingleModeSelectModalContainer,
-  SingleModeSelectModalTitle,
   SingleModeSelectModalContent,
   SingleModeSelectModalButtonContainer,
   ModeSelectImageWrap,
@@ -23,7 +22,7 @@ export default function SingleModeSelectModal(): JSX.Element {
 
   return (
     <Modal
-      title=""
+      title="싱글모드"
       isOpen={isSingleModeSelectModalOpen}
       onClose={() => {
         dispatch(modalAction.radioSingleModeSelectModal());
@@ -32,7 +31,6 @@ export default function SingleModeSelectModal(): JSX.Element {
       backgroundColor="#FFD7E7"
     >
       <SingleModeSelectModalContainer>
-        <SingleModeSelectModalTitle>싱글모드</SingleModeSelectModalTitle>
         <SingleModeSelectModalContent>{'홀로 강하게 키운다!\n오늘의 내가 갈 길은?'}</SingleModeSelectModalContent>
         <SingleModeSelectModalButtonContainer>
           <ModeSelectImageWrap>

--- a/src/components/single-mode-select-modal/single-mode-select-modal.style.tsx
+++ b/src/components/single-mode-select-modal/single-mode-select-modal.style.tsx
@@ -4,14 +4,6 @@ export const SingleModeSelectModalContainer = styled.div`
   padding: 24px 0;
 `;
 
-export const SingleModeSelectModalTitle = styled.div`
-  margin-top: 44px;
-  text-align: center;
-  font-size: 42px;
-  font-weight: bold;
-  font-family: 'neodgm';
-`;
-
 export const ModeSelectImageWrap = styled.button`
   border: none;
   cursor: pointer;
@@ -27,7 +19,7 @@ export const ModeSelectImage = styled.img`
 export const SingleModeSelectModalContent = styled.div`
   white-space: pre-wrap;
   text-align: center;
-  margin: 40px 0;
+  margin-bottom: 57px;
   color: grey;
   font-size: 24px;
   font-family: 'neodgm';


### PR DESCRIPTION
기존)
modal 컴포넌트의 header를 안쓰고 모든 모달에서 타이틀을 직접 만들어 줬었음.

변경)
modal 컴포넌트의 header에 모달 타이틀 넣고 props로 타이틀컬러(titleColor)를 선택적 매개변수로 받음.  

결론)
modal 컴포넌트를 활용하는 모달창에서 따로 타이틀을 만들어줄 필요가 없어짐