### PR TITLE
fix: 캐릭터 디폴트 값 설정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <!-- <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" /> -->
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/src/routes/main/main.component.tsx
+++ b/src/routes/main/main.component.tsx
@@ -65,11 +65,17 @@ export default function Main(): JSX.Element {
         <PomodoroTimer />
       </TimerContainer>
       <CharacterContainer>
-        {getRandomCompleted && (
+        {getRandomCompleted ? (
           <Character
             nickname={nickName}
             characterImgSrc={`${process.env.REACT_APP_IMG_URL}/character/all/work/0${characterImgCode}_01.png`}
             triangleImgSrc={`${process.env.REACT_APP_IMG_URL}/icons/arrow/0${triangleImgCode}.png`}
+          />
+        ) : (
+          <Character
+            nickname="포동포동 아기고양이"
+            characterImgSrc={`${process.env.REACT_APP_IMG_URL}/character/all/work/01_01.png`}
+            triangleImgSrc={`${process.env.REACT_APP_IMG_URL}/icons/arrow/01.png`}
           />
         )}
       </CharacterContainer>

--- a/src/store/modules/main/main.slice.ts
+++ b/src/store/modules/main/main.slice.ts
@@ -10,9 +10,9 @@ export interface MainState {
 
 const initialState: MainState = {
   getRandomChracter: false,
-  nickname: '',
-  characterImageCode: 0,
-  triangleImageCode: 0,
+  nickname: '포동포동한 아기고양이',
+  characterImageCode: 1,
+  triangleImageCode: 1,
 };
 
 export const getRandomAsync = createAsyncThunk('main/getCharacter', async () => {


### PR DESCRIPTION
### 배포 시 문제
https에서 http로의 요청으로 인해 block됨

### 해결 ❌
- 백엔드에서 당장 해결 어렵다 함
- 임시방편으로 서버에서 캐릭터 닉네임이랑 이미지 코드 받아올 때 에러나면 보여줄 디폴트 값만 설정해놓음